### PR TITLE
Fixed shipping line condition for deletion

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -162,7 +162,8 @@ class Sale:
                     'sequence': 9999,  # XXX
                 }]),
                 ('delete', [
-                    line for line in self.lines if line.shipment_cost
+                    line for line in self.lines
+                    if line.shipment_cost is not None
                 ]),
             ]
         })


### PR DESCRIPTION
shipment_cost can be `0` so check explicitly for None