### PR TITLE
Factor add shipping line

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -167,6 +167,12 @@ class Sale:
         :param shipment_cost: The shipment cost calculated according to carrier
         :param description: Shipping line description
         """
+        sequence = 9999
+        if self.lines:
+            last_line = self.lines[-1]
+            if last_line.sequence is not None:
+                sequence = last_line.sequence + 1
+
         return {
             'type': 'line',
             'product': self.carrier.carrier_product.id,
@@ -177,7 +183,7 @@ class Sale:
             'shipment_cost': shipment_cost,
             'amount': shipment_cost,
             'taxes': [],
-            'sequence': 9999,  # XXX
+            'sequence': sequence,
             }
 
     def _get_carrier_context(self):

--- a/sale.py
+++ b/sale.py
@@ -151,24 +151,34 @@ class Sale:
         """
         self.__class__.write([self], {
             'lines': [
-                ('create', [{
-                    'type': 'line',
-                    'product': self.carrier.carrier_product.id,
-                    'description': description,
-                    'quantity': 1,  # XXX
-                    'unit': self.carrier.carrier_product.sale_uom.id,
-                    'unit_price': shipment_cost,
-                    'shipment_cost': shipment_cost,
-                    'amount': shipment_cost,
-                    'taxes': [],
-                    'sequence': 9999,  # XXX
-                }]),
+                ('create', [self._get_shipping_line(
+                                shipment_cost, description)]),
                 ('delete', [
                     line for line in self.lines
                     if line.shipment_cost is not None
                 ]),
             ]
         })
+
+    def _get_shipping_line(self, shipment_cost, description):
+        """
+        This method takes shipping_cost and description as arguments and
+        gets the values for a shipping line.
+        :param shipment_cost: The shipment cost calculated according to carrier
+        :param description: Shipping line description
+        """
+        return {
+            'type': 'line',
+            'product': self.carrier.carrier_product.id,
+            'description': description,
+            'quantity': 1,  # XXX
+            'unit': self.carrier.carrier_product.sale_uom.id,
+            'unit_price': shipment_cost,
+            'shipment_cost': shipment_cost,
+            'amount': shipment_cost,
+            'taxes': [],
+            'sequence': 9999,  # XXX
+            }
 
     def _get_carrier_context(self):
         "Pass sale in the context"


### PR DESCRIPTION
- Factoring out _get_shipping_line from add_shipping_line for extensibility.

 Could be needed to e.g. get taxes on the shipment line.

- Providing a better sequence handling for the shipment line.